### PR TITLE
Extended viss

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,4 +10,4 @@ COPY . ./
 RUN pip install --no-cache-dir -r requirements.txt
 
 # Command to run the compiled executable
-CMD ["python", "tiniyvissv2.py"]
+ENTRYPOINT ["python", "tiniyvissv2.py"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,13 @@
+FROM python:3.8 AS builder
+
+# Set the working directory inside the container
+WORKDIR /
+
+# Copy the Python script and requirements file into the container
+COPY . ./
+
+# Install the required Python packages
+RUN pip install --no-cache-dir -r requirements.txt
+
+# Command to run the compiled executable
+CMD ["python", "tiniyvissv2.py"]

--- a/datapointhelper.py
+++ b/datapointhelper.py
@@ -1,5 +1,5 @@
 
-from kuksa_client.grpc import Datapoint
+from kuksa_client.grpc import Datapoint, Metadata
 ''' {
                 "action": "get",
                 "requestId": "8756",
@@ -20,5 +20,19 @@ def populate_datapoints(data_from_db: "dict[str, Datapoint]"):
         data["dp"] = {}
         data["dp"]["ts"] = dp.timestamp.isoformat()
         data["dp"]["value"] = dp.value
+
+    return data
+
+def populate_metadata(data_from_db: "dict[str, Metadata]"):
+    data = {}  # VISSv2 a bit buggy, this is an object/dict for single paths, and array otherwise
+
+    for path, metadata in data_from_db.items():
+        if metadata is None:
+            print(f"No data for {path}, skipping")
+            continue
+        data["path"] = path
+        data["metadata"] = {}
+        data["metadata"]["entry_type"] = metadata.entry_type
+        data["metadata"]["data_type"] = metadata.data_type
 
     return data

--- a/test.py
+++ b/test.py
@@ -33,6 +33,19 @@ async def hello():
         rep = await websocket.recv()
         print(f"<<< {rep}")
 
+        await websocket.send('''{"action": "getMetaData", "path": "Vehicle.OBD.Speed", "requestId":"sddf"}''')
+        rep = await websocket.recv()
+        print(f"<<< {rep}")
+
+        await websocket.send('''{"action": "getMetaData", "path": "Vehicle.NotExist", "requestId":"sddf"}''')
+        rep = await websocket.recv()
+        print(f"<<< {rep}")
+
+        await websocket.send('''{"action": "provide", "path": "Vehicle.Speed", "value": "20", "requestId":"sddf"}''')
+        rep = await websocket.recv()
+        print(f"<<< {rep}")
+
+
         print("SEEEEEEEEEET")
 
         await websocket.send('''{"action": "set"}''')

--- a/tiniyvissv2.py
+++ b/tiniyvissv2.py
@@ -35,7 +35,7 @@ async def vissv2(websocket):
         print(f"RX {msg}")
         try:
             msgObj = json.loads(msg)
-            await vissv2impl.process_request(websocket, kuksa, msgObj)
+            await vissv2impl.process_request(websocket, kuksa, msgObj, provideEnable)
         except json.JSONDecodeError as exp:
             await websocket.send(err.create_badrequest_error(f"The request is not valid JSON:{exp}"))
         except Exception as exp:
@@ -48,12 +48,13 @@ async def vissv2(websocket):
 async def main(args):
     print(f"Listening on port {args.port}")
     print(f"Will use {args.dbhost} port {args.dbport} for databroker connection")
-    async with websockets.serve(vissv2, "localhost", args.port, subprotocols=["VISSv2"]):
+    async with websockets.serve(vissv2, "127.0.0.1", args.port, subprotocols=["VISSv2"]):
         await asyncio.Future()  # run forever
 
 if __name__ == "__main__":
     global dbhost
     global dbport
+    global provideEnable
     parser = argparse.ArgumentParser()
     parser.add_argument(
         '--dbhost', help="KUKSA databroker host", default="localhost")
@@ -61,8 +62,11 @@ if __name__ == "__main__":
         '--dbport', type=int, help="KUKSA databroker port", default=55555)
     parser.add_argument(
         '--port', type=int, help="VISS websocket port", default=8090)
+    parser.add_argument(
+        '--provide', type=bool, help="enable provide for VISS interface, should not be in VISS per definition but for usability we can enable it", default=False)
     args = parser.parse_args()
     dbhost = args.dbhost
     dbport = args.dbport
+    provideEnable = args.provide
 
     asyncio.run(main(args))

--- a/tiniyvissv2.py
+++ b/tiniyvissv2.py
@@ -58,7 +58,7 @@ if __name__ == "__main__":
     parser.add_argument(
         '--dbhost', help="KUKSA databroker host", default="localhost")
     parser.add_argument(
-        '--dbport', type=int, help="KUKSA databroker port", default=555555)
+        '--dbport', type=int, help="KUKSA databroker port", default=55555)
     parser.add_argument(
         '--port', type=int, help="VISS websocket port", default=8090)
     args = parser.parse_args()

--- a/vissv2impl.py
+++ b/vissv2impl.py
@@ -328,12 +328,16 @@ async def process_subscribe(websocket, kuksa, msg):
         return
 
 
-async def process_request(websocket, kuksa, msg):
+async def process_request(websocket, kuksa, msg, provide_enabled):
     if "action" not in msg:
         await websocket.send(err.create_badrequest_error("The request does not contain an action"))
         return
+    
+    actions = ["get", "set", "subscribe", "getMetaData"]
+    if provide_enabled:
+        actions.append("provide")
 
-    if msg["action"] not in ["get", "set", "subscribe", "getMetaData", "provide"]:
+    if msg["action"] not in actions:
         await websocket.send(err.create_badrequest_error(f"Unknown action {msg['action']}"))
         return
 
@@ -346,7 +350,7 @@ async def process_request(websocket, kuksa, msg):
     elif msg["action"] == "set":
         await process_set(websocket, kuksa, msg)
     
-    elif msg["action"] == "provide":
+    elif msg["action"] == "provide" and provide_enabled:
         await process_provide(websocket, kuksa, msg)
 
     elif msg["action"] == "subscribe":


### PR DESCRIPTION
Extends the current implementation of viss wrapper for databroker with getMetaData and provide. Provide will only be enabled if ecplicitly told by --provide True. This is because for usability it is nice to have but provide is not part of VISS spec.