### PR TITLE
Deprecating KUKSA-VISS

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,11 @@
 # KUKSA-VISS
 
+**NOTE: KUKSA-VISS is deprecated and will reach End-of-Life 2024-12-31!**
+
+*Basic [VISS version 2](https://www.w3.org/TR/viss2-transport/) websocket support has been added to*
+*[KUKSA Databroker](https://github.com/eclipse/kuksa.val/blob/master/doc/protocol/support.md)*
+*and this adapter is no longer needed!*
+
 A VISS2 compatible adapter for KUKSA databroker.
 
 VISS2 Spec: https://github.com/w3c/automotive


### PR DESCRIPTION
KUKSA Databroker has now some VISSv2 support, this one is not longer needed.
Suggesting that we follow same End-of-Life period as we have announced for KUKSA Server

Based on a discussion in https://github.com/eclipse-kuksa/.github/pull/1